### PR TITLE
downloader: fix invalid chars in album/artist name

### DIFF
--- a/ncm/downloader.py
+++ b/ncm/downloader.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import re
 import requests
 
 from ncm import config
@@ -20,9 +19,9 @@ def download_song_by_song(song, download_folder, sub_folder=True):
     # get song info
     api = CloudApi()
     song_id = song['id']
-    song_name = re.sub(r'[\\/:*?"<>|]', ' ', song['name'])    # Replace illegal character with ' '
-    artist_name = song['artists'][0]['name']
-    album_name = song['album']['name']
+    song_name = encode_path(song['name'])
+    artist_name = encode_path(song['artists'][0]['name'])
+    album_name = encode_path(song['album']['name'])
 
     # update song file name by config
     song_file_name = '{}.mp3'.format(song_name)
@@ -66,6 +65,19 @@ def download_song_by_song(song, download_folder, sub_folder=True):
 
     # delete cover file
     os.remove(cover_file_path)
+
+
+def encode_path(path):
+    """Replace illegal character with ` `."""
+    path = path.replace('/', ' ')
+    path = path.replace(':', ' ')
+    path = path.replace('*', ' ')
+    path = path.replace('?', ' ')
+    path = path.replace('"', ' ')
+    path = path.replace('<', ' ')
+    path = path.replace('>', ' ')
+    path = path.replace('|', ' ')
+    return path
 
 
 def download_file(file_url, file_name, folder):


### PR DESCRIPTION
If the name of an artist, an album
contains the forward slash character, a.k.a. `/`,
ncm will failed to create the directory to save the download file
and will abort its execution with an exception.

For example, the album `雨のち晴れ / What's your name?`
contains `/`, which is forbidden in unix systems.

https://music.163.com/#/album?id=2569036

Commit `cd3d043` replaces some special characters with white space
in track name,
but does not replace special characters in album and artist names.

This commit fix this issue by also replacing special characters
in album and artist names.

Related issue: #7

---
 ncm/downloader.py | 20 ++++++++++++++++----
 1 file changed, 16 insertions(+), 4 deletions(-)