### PR TITLE
Enhancement: Add song track number

### DIFF
--- a/ncm/file_util.py
+++ b/ncm/file_util.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from mutagen.mp3 import MP3, HeaderNotFoundError
-from mutagen.id3 import ID3, APIC, TPE1, TIT2, TALB, error
+from mutagen.id3 import ID3, APIC, TPE1, TIT2, TALB, TRCK, error
 from PIL import Image
 
 
@@ -15,6 +15,7 @@ def resize_img(file_path, max_size=(640, 640), quality=90):
     if img.size[0] > max_size[0] or img.size[1] > max_size[1]:
         img.thumbnail(max_size, Image.ANTIALIAS)
         img.save(file_path, quality=quality)
+
 
 
 def add_metadata_to_song(file_path, cover_path, song):
@@ -69,6 +70,13 @@ def add_metadata_to_song(file_path, cover_path, song):
         TALB(
             encoding=3,
             text=song['album']['name']
+        )
+    )
+    # add song track number
+    id3.add(
+        TRCK(
+            encoding=3,
+            text='{}/{}'.format(song['no'], song['album']['size'])
         )
     )
     id3.save(v2_version=3)


### PR DESCRIPTION
The track number in netease music files is not always exists(eg: `ncm -a 35834085`).

Always add song track number to ensure it will never be lost.